### PR TITLE
Implement chat screen with local message storage

### DIFF
--- a/lib/src/core/constant/string_constant/message_string_constant.dart
+++ b/lib/src/core/constant/string_constant/message_string_constant.dart
@@ -1,1 +1,4 @@
-class MessageStringConstant {}
+class MessageStringConstant {
+  static const String inputHint = '메시지를 입력하세요';
+  static const String me = 'me';
+}

--- a/lib/src/environment/app_build_setting.dart
+++ b/lib/src/environment/app_build_setting.dart
@@ -8,6 +8,7 @@ class AppBuildSetting {
     WidgetsFlutterBinding.ensureInitialized();
 
     await Hive.initFlutter();
+    await Hive.openBox('messages');
 
     await SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,

--- a/lib/src/presentation/meeting_room_list/meeting_room_list_screen.dart
+++ b/lib/src/presentation/meeting_room_list/meeting_room_list_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_riverpod/src/consumer.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:mobile1_flutter_coding_test/src/core/common/exception/custom_exception.dart';
 import 'package:mobile1_flutter_coding_test/src/core/common/extension/data_time_extension.dart';
@@ -14,6 +15,7 @@ import 'package:mobile1_flutter_coding_test/src/presentation/common/component/us
 import 'package:mobile1_flutter_coding_test/src/presentation/common/error_screen.dart';
 import 'package:mobile1_flutter_coding_test/src/presentation/meeting_room_list/mixin/meeting_room_event.dart';
 import 'package:mobile1_flutter_coding_test/src/presentation/meeting_room_list/mixin/meeting_room_state.dart';
+import 'package:mobile1_flutter_coding_test/src/presentation/message/message_screen.dart';
 
 part 'view/meeting_room_list_view.dart';
 

--- a/lib/src/presentation/meeting_room_list/view/meeting_room_list_view.dart
+++ b/lib/src/presentation/meeting_room_list/view/meeting_room_list_view.dart
@@ -15,7 +15,16 @@ class _MeetingRoomListView extends BaseView {
             lastMessage.timestamp.updateLastMessageDateFormat;
 
         return ListTile(
-          onTap: () {},
+          onTap: () {
+            context.goNamed(
+              MessageScreen.route,
+              pathParameters: {'roomId': meetingRoom.roomId},
+              extra: {
+                'roomId': meetingRoom.roomId,
+                'roomName': meetingRoom.roomName,
+              },
+            );
+          },
           leading:
               UserAvatarWidget(profilePictureUrl: meetingRoom.thumbnailImage),
           title: Text(meetingRoom.roomName),

--- a/lib/src/presentation/message/message_screen.dart
+++ b/lib/src/presentation/message/message_screen.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:mobile1_flutter_coding_test/src/core/common/exception/custom_exception.dart';
+import 'package:mobile1_flutter_coding_test/src/core/constant/string_constant/message_string_constant.dart';
 import 'package:mobile1_flutter_coding_test/src/presentation/common/base/base_screen.dart';
 import 'package:mobile1_flutter_coding_test/src/presentation/common/component/custom_app_bar_widget.dart';
+import 'package:mobile1_flutter_coding_test/src/presentation/common/component/loading_indicator.dart';
+import 'package:mobile1_flutter_coding_test/src/presentation/common/error_screen.dart';
+import 'package:mobile1_flutter_coding_test/src/presentation/message/mixin/message_event.dart';
+import 'package:mobile1_flutter_coding_test/src/presentation/message/mixin/message_state.dart';
+import 'package:mobile1_flutter_coding_test/src/presentation/message/provider/message_provider.dart';
 
 part 'view/message_view.dart';
 part 'view/message_input_view.dart';
 
-class MessageScreen extends BaseScreen {
+class MessageScreen extends BaseScreen with MessageState, MessageEvent {
   static const String route = 'MessageScreen';
 
   final String roomId;
@@ -19,19 +28,44 @@ class MessageScreen extends BaseScreen {
 
   @override
   Widget buildScreen(BuildContext context, WidgetRef ref) {
-    return Container();
-    // return watchMessages(ref: ref, roomId: roomId).when(
-    //   data: (List<MessageEntity> messages) {
-    //     return Column(
-    //       children: [],
-    //     );
-    //   },
-    //   error: (error, stackTrace) => ErrorView(
-    //     appException: error is AppException ? error : const UnknownException(),
-    //     onPressed: () {},
-    //   ),
-    //   loading: () => const LoadingIndicator(),
-    // );
+    final TextEditingController controller = useTextEditingController();
+
+    final AsyncValue<List<MessageEntity>> messages =
+        watchMessages(ref: ref, roomId: roomId);
+
+    return Column(
+      children: [
+        Expanded(
+          child: messages.when(
+            data: (List<MessageEntity> msgList) {
+              return _MessageListView(messages: msgList);
+            },
+            error: (error, stackTrace) => ErrorView(
+              appException:
+                  error is AppException ? error : const UnknownException(),
+              onPressed: () async {
+                await ref
+                    .read(messageListProvider(roomId).notifier)
+                    .loadMessages();
+              },
+            ),
+            loading: () => const LoadingIndicator(),
+          ),
+        ),
+        _MessageInputView(
+          controller: controller,
+          onSend: (String text) async {
+            await sendMessage(
+              ref: ref,
+              roomId: roomId,
+              sender: MessageStringConstant.me,
+              content: text,
+            );
+            controller.clear();
+          },
+        ),
+      ],
+    );
   }
 
   @override

--- a/lib/src/presentation/message/mixin/message_event.dart
+++ b/lib/src/presentation/message/mixin/message_event.dart
@@ -1,1 +1,15 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mobile1_flutter_coding_test/src/presentation/message/provider/message_provider.dart';
 
+mixin class MessageEvent {
+  Future<void> sendMessage({
+    required WidgetRef ref,
+    required String roomId,
+    required String sender,
+    required String content,
+  }) async {
+    await ref
+        .read(messageListProvider(roomId).notifier)
+        .sendMessage(sender: sender, content: content);
+  }
+}

--- a/lib/src/presentation/message/mixin/message_state.dart
+++ b/lib/src/presentation/message/mixin/message_state.dart
@@ -1,1 +1,9 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:mobile1_flutter_coding_test/src/domain/entity/message_list_response_entity.dart';
+import 'package:mobile1_flutter_coding_test/src/presentation/message/provider/message_provider.dart';
 
+mixin class MessageState {
+  AsyncValue<List<MessageEntity>> watchMessages({required WidgetRef ref, required String roomId}) {
+    return ref.watch(messageListProvider(roomId));
+  }
+}

--- a/lib/src/presentation/message/provider/message_provider.dart
+++ b/lib/src/presentation/message/provider/message_provider.dart
@@ -1,0 +1,69 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:mobile1_flutter_coding_test/src/domain/entity/message_list_response_entity.dart';
+import 'package:mobile1_flutter_coding_test/src/domain/usecase/meeting_room_usecase.dart';
+
+class MessageListNotifier extends StateNotifier<AsyncValue<List<MessageEntity>>> {
+  final Ref _ref;
+  final String _roomId;
+
+  MessageListNotifier({required Ref ref, required String roomId})
+      : _ref = ref,
+        _roomId = roomId,
+        super(const AsyncLoading()) {
+    loadMessages();
+  }
+
+  Future<void> loadMessages() async {
+    try {
+      final box = Hive.box('messages');
+      final List<dynamic>? stored = box.get(_roomId) as List<dynamic>?;
+      List<MessageEntity> local = [];
+      if (stored != null) {
+        local = stored
+            .map((e) => MessageEntity.fromJson(Map<String, dynamic>.from(e)))
+            .toList();
+      }
+
+      final MessageUseCase useCase = _ref.read(messageUseCaseProvider);
+      final MessageListResponseEntity remote = await useCase.getMessageList();
+      final List<MessageEntity> remoteMessages =
+          remote.messages.where((m) => m.roomId == _roomId).toList();
+
+      final Map<String, MessageEntity> merged = {
+        for (var m in remoteMessages) m.messageId: m,
+        for (var m in local) m.messageId: m,
+      };
+      final List<MessageEntity> messages = merged.values.toList()
+        ..sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+      state = AsyncData(messages);
+      await _save(messages);
+    } catch (e, st) {
+      state = AsyncError(e, st);
+    }
+  }
+
+  Future<void> sendMessage({required String sender, required String content}) async {
+    final MessageEntity message = MessageEntity(
+      roomId: _roomId,
+      messageId: 'local-${DateTime.now().millisecondsSinceEpoch}',
+      sender: sender,
+      content: content,
+      timestamp: DateTime.now(),
+    );
+    final List<MessageEntity> current = [...state.value ?? []]..add(message);
+    current.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+    state = AsyncData(current);
+    await _save(current);
+  }
+
+  Future<void> _save(List<MessageEntity> messages) async {
+    final box = Hive.box('messages');
+    await box.put(_roomId, messages.map((e) => e.toJson()).toList());
+  }
+}
+
+final messageListProvider = StateNotifierProvider.family<MessageListNotifier, AsyncValue<List<MessageEntity>>, String>((ref, roomId) {
+  return MessageListNotifier(ref: ref, roomId: roomId);
+});

--- a/lib/src/presentation/message/view/message_input_view.dart
+++ b/lib/src/presentation/message/view/message_input_view.dart
@@ -1,1 +1,38 @@
 part of '../message_screen.dart';
+
+class _MessageInputView extends BaseView {
+  final TextEditingController controller;
+  final ValueChanged<String> onSend;
+
+  const _MessageInputView({
+    required this.controller,
+    required this.onSend,
+  });
+
+  @override
+  Widget buildView(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: controller,
+              decoration: const InputDecoration(
+                hintText: MessageStringConstant.inputHint,
+              ),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.send),
+            onPressed: () {
+              final text = controller.text.trim();
+              if (text.isEmpty) return;
+              onSend(text);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/presentation/message/view/message_view.dart
+++ b/lib/src/presentation/message/view/message_view.dart
@@ -1,1 +1,22 @@
 part of '../message_screen.dart';
+
+class _MessageListView extends BaseView {
+  final List<MessageEntity> messages;
+  const _MessageListView({required this.messages});
+
+  @override
+  Widget buildView(BuildContext context, WidgetRef ref) {
+    return ListView.builder(
+      reverse: true,
+      itemCount: messages.length,
+      itemBuilder: (context, index) {
+        final message = messages[messages.length - 1 - index];
+        return ListTile(
+          title: Text(message.sender),
+          subtitle: Text(message.content),
+          trailing: Text(DateFormat('HH:mm').format(message.timestamp)),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- open Hive box at startup for message caching
- add state management for messages using `MessageListNotifier`
- implement chat UI with message list and input field
- allow navigating from meeting room list to chat screen
- store sent messages locally

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfef42afc832d9ef0f2a062ce9bb7