### PR TITLE
Add GitHub Actions workflow for Flutter CI

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -1,0 +1,30 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: subosito/flutter-action@v2
+      with:
+        channel: 'stable'
+
+    - name: Install dependencies
+      run: flutter pub get
+
+    - name: Analyze
+      run: flutter analyze
+
+    - name: Run tests
+      run: flutter test
+
+    - name: Build APK
+      run: flutter build apk --debug


### PR DESCRIPTION
## Summary
- add a basic GitHub Actions workflow to automatically build and test the Flutter project

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3cace998832dae280bdf3f55220e